### PR TITLE
Attempt to fix this package.

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -751,7 +751,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     return (
       <Modal
-        transparent={true}
+        transparent={false}
         animationType={'none'}
         visible={this.state.isVisible}
         onRequestClose={onBackButtonPress}


### PR DESCRIPTION
The `react-native-modal` package has a forced prop set to transparent={true}. Based off of the documentation here: https://github.com/facebook/react-native/issues/16597 we are better off trying to set this to false.